### PR TITLE
Specify the SymPy version in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY install_deps.sh /app/
 RUN /app/install_deps.sh
 
 # Install Cairo0 for end-to-end test.
-RUN pip install cairo-lang==0.12.0
+RUN pip install sympy==1.12.1 cairo-lang==0.12.0
 
 COPY docker_common_deps.sh /app/
 WORKDIR /app/


### PR DESCRIPTION
Resolve ImportError: cannot import name 'igcdex' from 'sympy.core.numbers' when building with Docker
SymPy was updated last week, and the location of igcdex has changed.

The new version of cairo-lang is still in pre-release, so fix the SymPy version instead.