### PR TITLE
Pin sympy to 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN /app/install_deps.sh
 
 # Install Cairo0 for end-to-end test.
 RUN pip install cairo-lang==0.12.0
+RUN pip install sympy==1.12.1
 
 COPY docker_common_deps.sh /app/
 WORKDIR /app/


### PR DESCRIPTION
Pin sympy to 1.12.1 in the Dockerfile using pip, otherwise the build fails with:

```
ImportError: cannot import name 'igcdex' from 'sympy.core.numbers' (/usr/local/lib/python3.9/dist-packages/sympy/core/numbers.py)
```