### PR TITLE
docs: Update link to CRYPTOGAMS license

### DIFF
--- a/src/third_party/XKCP/README.markdown
+++ b/src/third_party/XKCP/README.markdown
@@ -85,7 +85,7 @@ Most of the source and header files in the XKCP are released to the **public dom
 * [`lib/common/brg_endian.h`](lib/common/brg_endian.h) is copyrighted by Brian Gladman and comes with a BSD 3-clause license;
 * [`tests/UnitTests/genKAT.c`](tests/UnitTests/genKAT.c) is based on [SHA-3 contest's code by Larry Bassham, NIST](http://csrc.nist.gov/groups/ST/hash/sha-3/documents/KAT1.zip), which he licensed under a BSD 3-clause license;
 * [`tests/UnitTests/timing.h`](tests/UnitTests/timing.h) is based on code by Doug Whiting, which he released to the public domain;
-* [`KeccakP-1600-AVX2.s`](lib/low/KeccakP-1600/OptimizedAVX2/KeccakP-1600-AVX2.s) is licensed under the [CRYPTOGAMS license](http://www.openssl.org/~appro/cryptogams/) (BSD-like).
+* [`KeccakP-1600-AVX2.s`](lib/low/KeccakP-1600/OptimizedAVX2/KeccakP-1600-AVX2.s) is licensed under the [CRYPTOGAMS license](https://github.com/dot-asm/cryptogams/blob/master/LICENSE) (BSD-like).
 
 
 


### PR DESCRIPTION
Description:
Link to CRYPTOGAMS license is no longer accessible.

Proposal:
Redirect broken link to github LICENSE file